### PR TITLE
Fix apple-clang 8.0 for travis (xcode8.0 -> xcode8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
 matrix:
    include:
        - os: osx
-         osx_image: xcode8.0 # apple-clang 8.0
+         osx_image: xcode8 # apple-clang 8.0
          language: generic
          env:
        - os: osx


### PR DESCRIPTION
There was a minor fault in my last PR, the name of the image should be `xcode8`, not `xcode8.0`.
Invalid image names are apparently ignored in silence and the [default](https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version) is picked...